### PR TITLE
Deep/23

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -18,5 +18,5 @@ android {
 dependencies {
   implementation(project(":waffle"))
 
-  implementation(libs.appcompat)
+  implementation(libs.androidx.appcompat)
 }

--- a/build-logic/src/main/kotlin/build-logics.kt
+++ b/build-logic/src/main/kotlin/build-logics.kt
@@ -112,10 +112,10 @@ internal class AndroidTestJUnitPlugin : BuildLogicPlugin({
   useTestPlatformForTarget()
   dependencies {
     setupEspresso(
-      espressoCore = libs.findLibrary("androidx-test-espresso-core").get(),
+      espressoCore = libs.findLibrary("test-espresso-core").get(),
     )
     setupAndroidxTest(
-      junitExt = libs.findLibrary("androidx-test-ext").get(),
+      junitExt = libs.findLibrary("test-junit-ktx").get(),
     )
   }
 })

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,6 +29,7 @@ androidx-test-espresso-core = { group = "androidx.test.espresso", name = "espres
 androidx-test-ext = { group = "androidx.test.ext", name = "junit-ktx", version.ref = "androidx-junit-ext" }
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "androidx-appcompat" }
 androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "androidx-constraintlayout" }
+
 gradle-android = { module = "com.android.tools.build:gradle", version.ref = "gradle-android" }
 
 kotlin-gradle = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin-core" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,8 +1,8 @@
 [versions]
 androidx-espresso = "3.5.1"
 androidx-junit-ext = "1.1.5"
+androidx-appcompat = "1.6.1"
 androidx-constraintlayout = "2.1.4"
-appcompat = "1.6.1"
 gradle-android = "8.0.2"
 gradle-dependency-handler-extensions = "1.1.0"
 
@@ -26,8 +26,8 @@ kotlin-ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "kotlin-kt
 [libraries]
 androidx-test-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "androidx-espresso" }
 androidx-test-ext = { group = "androidx.test.ext", name = "junit-ktx", version.ref = "androidx-junit-ext" }
+androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "androidx-appcompat" }
 androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "androidx-constraintlayout" }
-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "appcompat" }
 gradle-android = { module = "com.android.tools.build:gradle", version.ref = "gradle-android" }
 
 kotlin-gradle = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin-core" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 androidx-espresso = "3.5.1"
 androidx-junit-ext = "1.1.5"
+androidx-constraintlayout = "2.1.4"
 appcompat = "1.6.1"
 gradle-android = "8.0.2"
 gradle-dependency-handler-extensions = "1.1.0"
@@ -25,6 +26,7 @@ kotlin-ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "kotlin-kt
 [libraries]
 androidx-test-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "androidx-espresso" }
 androidx-test-ext = { group = "androidx.test.ext", name = "junit-ktx", version.ref = "androidx-junit-ext" }
+androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "androidx-constraintlayout" }
 appcompat = { module = "androidx.appcompat:appcompat", version.ref = "appcompat" }
 gradle-android = { module = "com.android.tools.build:gradle", version.ref = "gradle-android" }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,8 +25,6 @@ kotlin-detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "kotlin-dete
 kotlin-ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "kotlin-ktlint-gradle" }
 
 [libraries]
-androidx-test-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "androidx-espresso" }
-androidx-test-ext = { group = "androidx.test.ext", name = "junit-ktx", version.ref = "androidx-junit-ext" }
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "androidx-appcompat" }
 androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "androidx-constraintlayout" }
 
@@ -36,9 +34,11 @@ kotlin-gradle = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.
 
 # This isn't strictly used but allows Renovate to see us using the ktlint artifact
 kotlin-ktlint = { module = "com.pinterest:ktlint", version.ref = "kotlin-ktlint-source" }
+test-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "androidx-espresso" }
 test-kotest-framework = { module = "io.kotest:kotest-runner-junit5-jvm", version.ref = "test-kotest" }
 test-kotest-assertion-core = { module = "io.kotest:kotest-assertions-core-jvm", version.ref = "test-kotest" }
 test-junit-core = { module = "junit:junit", version.ref = "test-junit-core" }
 test-junit-engine = { module = "org.junit.vintage:junit-vintage-engine", version.ref = "test-junit-engine" } # testRuntimeOnly
 test-junit-compose = { module = "androidx.compose.ui:ui-test-junit4", version.ref = "test-junit-compose" } # androidTestImplementation
+test-junit-ktx = { group = "androidx.test.ext", name = "junit-ktx", version.ref = "androidx-junit-ext" }
 detekt-plugin-formatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", version.ref = "kotlin-detekt" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,6 +3,7 @@ androidx-espresso = "3.5.1"
 androidx-junit-ext = "1.1.5"
 androidx-appcompat = "1.6.1"
 androidx-constraintlayout = "2.1.4"
+
 gradle-android = "8.0.2"
 gradle-dependency-handler-extensions = "1.1.0"
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -31,4 +31,5 @@ buildCache {
 include(
   ":app",
   ":waffle",
+  ":waffle:preview",
 )

--- a/waffle/build.gradle.kts
+++ b/waffle/build.gradle.kts
@@ -30,5 +30,5 @@ android {
 }
 
 dependencies {
-  implementation(libs.appcompat)
+  implementation(libs.androidx.appcompat)
 }

--- a/waffle/preview/build.gradle.kts
+++ b/waffle/preview/build.gradle.kts
@@ -16,6 +16,7 @@ android {
 
   buildFeatures {
     viewBinding = true
+    dataBinding = true
   }
 }
 

--- a/waffle/preview/build.gradle.kts
+++ b/waffle/preview/build.gradle.kts
@@ -23,6 +23,6 @@ android {
 dependencies {
   implementation(projects.waffle)
 
-  implementation(libs.appcompat)
+  implementation(libs.androidx.appcompat)
   implementation(libs.androidx.constraintlayout)
 }

--- a/waffle/preview/build.gradle.kts
+++ b/waffle/preview/build.gradle.kts
@@ -21,7 +21,7 @@ android {
 }
 
 dependencies {
-  implementation(project(":waffle"))
+  implementation(projects.waffle)
 
   implementation(libs.appcompat)
 }

--- a/waffle/preview/build.gradle.kts
+++ b/waffle/preview/build.gradle.kts
@@ -24,4 +24,5 @@ dependencies {
   implementation(projects.waffle)
 
   implementation(libs.appcompat)
+  implementation(libs.androidx.constraintlayout)
 }

--- a/waffle/preview/build.gradle.kts
+++ b/waffle/preview/build.gradle.kts
@@ -1,0 +1,26 @@
+/*
+ * Designed and developed by DoneDone Team 2023.
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/TodayDoneDone/donedone-android/blob/main/LICENSE
+ */
+
+@file:Suppress("UnstableApiUsage")
+
+plugins {
+  donedone("android-application")
+}
+
+android {
+  namespace = "me.donedone.waffle.preview"
+
+  buildFeatures {
+    viewBinding = true
+  }
+}
+
+dependencies {
+  implementation(project(":waffle"))
+
+  implementation(libs.appcompat)
+}

--- a/waffle/preview/src/main/AndroidManifest.xml
+++ b/waffle/preview/src/main/AndroidManifest.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Designed and developed by DoneDone Team 2023.
+  ~
+  ~ Licensed under the MIT.
+  ~ Please see full license: https://github.com/TodayDoneDone/donedone-android/blob/main/LICENSE
+  -->
+
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <application
+        android:label="WaffleCatalog"
+        android:theme="@style/WaffleTheme"
+        tools:ignore="MissingApplicationIcon">
+
+        <activity
+            android:name=".MainActivity"
+            android:exported="true">
+
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+
+        </activity>
+
+    </application>
+
+</manifest>

--- a/waffle/preview/src/main/AndroidManifest.xml
+++ b/waffle/preview/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?><!--
+<?xml version="1.0" encoding="utf-8"?>
+<!--
   ~ Designed and developed by DoneDone Team 2023.
   ~
   ~ Licensed under the MIT.
@@ -23,7 +24,9 @@
             </intent-filter>
 
         </activity>
-
+        <activity
+            android:name=".button.WaffleButtonActivity"
+            android:exported="false" />
     </application>
 
 </manifest>

--- a/waffle/preview/src/main/AndroidManifest.xml
+++ b/waffle/preview/src/main/AndroidManifest.xml
@@ -10,7 +10,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <application
-        android:label="WaffleCatalog"
+        android:label="WafflePreview"
         android:theme="@style/WaffleTheme"
         tools:ignore="MissingApplicationIcon">
 
@@ -26,6 +26,7 @@
         </activity>
         <activity
             android:name=".button.WaffleButtonActivity"
+            android:label="Waffle Button Activity"
             android:exported="false" />
     </application>
 

--- a/waffle/preview/src/main/kotlin/me/donedone/waffle/preview/MainActivity.kt
+++ b/waffle/preview/src/main/kotlin/me/donedone/waffle/preview/MainActivity.kt
@@ -33,10 +33,10 @@ class MainActivity : AppCompatActivity() {
   private fun getSampleItemList(): List<SampleItem> {
     val df = DexFile(packageCodePath)
     return df.entries().toList()
-      .filter { it.contains(this.packageName) }
-      .mapNotNull {
+      .filter { className -> className.contains(this.packageName) }
+      .mapNotNull { className ->
         try {
-          Class.forName(it)
+          Class.forName(className)
         } catch (_: ClassNotFoundException) {
           null
         } catch (_: ExceptionInInitializerError) {
@@ -44,12 +44,12 @@ class MainActivity : AppCompatActivity() {
         } catch (_: LinkageError) {
           null
         }
-      }.mapNotNull {
-        it.getAnnotation(WaffleSample::class.java)?.run {
-          this to it
+      }.mapNotNull { clazz ->
+        clazz.getAnnotation(WaffleSample::class.java)?.run {
+          this to clazz
         }
-      }.map {
-        SampleItem(it.first.title, it.second)
+      }.map { pairItem: Pair<WaffleSample, Class<*>> ->
+        SampleItem(pairItem.first.title, pairItem.second)
       }
   }
 

--- a/waffle/preview/src/main/kotlin/me/donedone/waffle/preview/MainActivity.kt
+++ b/waffle/preview/src/main/kotlin/me/donedone/waffle/preview/MainActivity.kt
@@ -5,18 +5,16 @@
  * Please see full license: https://github.com/TodayDoneDone/donedone-android/blob/main/LICENSE
  */
 
-/*
- * Designed and developed by DoneDone Team 2023.
- *
- * Licensed under the MIT.
- * Please see full license: https://github.com/TodayDoneDone/donedone-android/blob/main/LICENSE
- */
-
 package me.donedone.waffle.preview
 
+import android.content.Context
+import android.content.Intent
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
+import dalvik.system.DexFile
+import me.donedone.waffle.preview.annotations.WaffleSample
 import me.donedone.waffle.preview.databinding.ActivityMainBinding
+import me.donedone.waffle.preview.databinding.ListItemSampleBinding
 
 class MainActivity : AppCompatActivity() {
 
@@ -24,5 +22,47 @@ class MainActivity : AppCompatActivity() {
     super.onCreate(savedInstanceState)
     val binding = ActivityMainBinding.inflate(layoutInflater)
     setContentView(binding.root)
+
+    getSampleItemList().forEach {
+      val item = ListItemSampleBinding.inflate(layoutInflater)
+      item.viewModel = it.toViewModel(this)
+      binding.container.addView(item.root)
+    }
   }
+
+  private fun getSampleItemList(): List<SampleItem> {
+    val df = DexFile(packageCodePath)
+    return df.entries().toList()
+      .filter { it.contains(this.packageName) }
+      .mapNotNull {
+        try {
+          Class.forName(it)
+        } catch (_: ClassNotFoundException) {
+          null
+        } catch (_: ExceptionInInitializerError) {
+          null
+        } catch (_: LinkageError) {
+          null
+        }
+      }.mapNotNull {
+        it.getAnnotation(WaffleSample::class.java)?.run {
+          this to it
+        }
+      }.map {
+        SampleItem(it.first.title, it.second)
+      }
+  }
+
+  private fun SampleItem.toViewModel(context: Context): SampleViewModel {
+    return SampleViewModel(
+      title = title,
+      action = {
+        startActivity(Intent(context, cls))
+      },
+    )
+  }
+
+  data class SampleItem(val title: String, val cls: Class<*>)
+
+  data class SampleViewModel(val title: String, val action: Runnable)
 }

--- a/waffle/preview/src/main/kotlin/me/donedone/waffle/preview/MainActivity.kt
+++ b/waffle/preview/src/main/kotlin/me/donedone/waffle/preview/MainActivity.kt
@@ -1,0 +1,28 @@
+/*
+ * Designed and developed by DoneDone Team 2023.
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/TodayDoneDone/donedone-android/blob/main/LICENSE
+ */
+
+/*
+ * Designed and developed by DoneDone Team 2023.
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/TodayDoneDone/donedone-android/blob/main/LICENSE
+ */
+
+package me.donedone.waffle.preview
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import me.donedone.waffle.preview.databinding.ActivityMainBinding
+
+class MainActivity : AppCompatActivity() {
+
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    val binding = ActivityMainBinding.inflate(layoutInflater)
+    setContentView(binding.root)
+  }
+}

--- a/waffle/preview/src/main/kotlin/me/donedone/waffle/preview/annotations/WaffleSample.kt
+++ b/waffle/preview/src/main/kotlin/me/donedone/waffle/preview/annotations/WaffleSample.kt
@@ -1,0 +1,12 @@
+/*
+ * Designed and developed by DoneDone Team 2023.
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/TodayDoneDone/donedone-android/blob/main/LICENSE
+ */
+
+package me.donedone.waffle.preview.annotations
+
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class WaffleSample(val title: String)

--- a/waffle/preview/src/main/kotlin/me/donedone/waffle/preview/button/WaffleButtonActivity.kt
+++ b/waffle/preview/src/main/kotlin/me/donedone/waffle/preview/button/WaffleButtonActivity.kt
@@ -1,0 +1,21 @@
+/*
+ * Designed and developed by DoneDone Team 2023.
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/TodayDoneDone/donedone-android/blob/main/LICENSE
+ */
+package me.donedone.waffle.preview.button
+
+import androidx.appcompat.app.AppCompatActivity
+import android.os.Bundle
+import me.donedone.waffle.preview.annotations.WaffleSample
+import me.donedone.waffle.preview.databinding.ActivityWaffleButtonBinding
+
+@WaffleSample(title = "Button Sample Activity")
+class WaffleButtonActivity : AppCompatActivity() {
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    val binding = ActivityWaffleButtonBinding.inflate(layoutInflater)
+    setContentView(binding.root)
+  }
+}

--- a/waffle/preview/src/main/res/layout/activity_main.xml
+++ b/waffle/preview/src/main/res/layout/activity_main.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Designed and developed by DoneDone Team 2023.
+  ~
+  ~ Licensed under the MIT.
+  ~ Please see full license: https://github.com/TodayDoneDone/donedone-android/blob/main/LICENSE
+  -->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+</LinearLayout>

--- a/waffle/preview/src/main/res/layout/activity_main.xml
+++ b/waffle/preview/src/main/res/layout/activity_main.xml
@@ -4,9 +4,13 @@
   ~ Licensed under the MIT.
   ~ Please see full license: https://github.com/TodayDoneDone/donedone-android/blob/main/LICENSE
   -->
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical">
+    android:layout_height="match_parent">
 
-</LinearLayout>
+    <LinearLayout
+        android:id="@+id/container"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical" />
+</ScrollView>

--- a/waffle/preview/src/main/res/layout/activity_waffle_button.xml
+++ b/waffle/preview/src/main/res/layout/activity_waffle_button.xml
@@ -5,68 +5,94 @@
   ~ Licensed under the MIT.
   ~ Please see full license: https://github.com/TodayDoneDone/donedone-android/blob/main/LICENSE
   -->
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content">
+    android:layout_height="match_parent">
 
-    <LinearLayout
-        android:layout_width="match_parent"
+    <Button
+        android:id="@+id/btn"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:orientation="vertical">
+        android:text="button"
+        app:layout_constraintBottom_toTopOf="@id/btn_default"
+        app:layout_constraintEnd_toStartOf="@id/wf_btn"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
-        <Button
-            android:id="@+id/btn"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="button" />
+    <me.donedone.waffle.android.widget.WaffleButton
+        android:id="@+id/wf_btn"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="button"
+        app:layout_constraintBottom_toTopOf="@id/wf_btn_default"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/btn"
+        app:layout_constraintTop_toTopOf="parent" />
 
-        <me.donedone.waffle.android.widget.WaffleButton
-            android:id="@+id/wf_btn"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="button" />
+    <Button
+        android:id="@+id/btn_default"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="default button"
+        app:layout_constraintBottom_toTopOf="@id/btn_done"
+        app:layout_constraintEnd_toStartOf="@id/wf_btn_default"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/btn"
+        app:waffleButtonStyle="Default" />
 
-        <Button
-            android:id="@+id/btn_default"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="default button"
-            app:waffleButtonStyle="Default" />
+    <me.donedone.waffle.android.widget.WaffleButton
+        android:id="@+id/wf_btn_default"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="default button"
+        app:layout_constraintBottom_toTopOf="@id/wf_btn_done"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/btn_default"
+        app:layout_constraintTop_toBottomOf="@id/wf_btn"
+        app:waffleButtonStyle="Default" />
 
-        <me.donedone.waffle.android.widget.WaffleButton
-            android:id="@+id/wf_btn_default"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="default button"
-            app:waffleButtonStyle="Default" />
+    <Button
+        android:id="@+id/btn_done"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="done button"
+        app:layout_constraintBottom_toTopOf="@id/btn_primary"
+        app:layout_constraintEnd_toStartOf="@id/wf_btn_done"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/btn_default"
+        app:waffleButtonStyle="Done" />
 
-        <Button
-            android:id="@+id/btn_done"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="done button"
-            app:waffleButtonStyle="Done" />
+    <me.donedone.waffle.android.widget.WaffleButton
+        android:id="@+id/wf_btn_done"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="done button"
+        app:layout_constraintBottom_toTopOf="@id/wf_btn_primary"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/btn_done"
+        app:layout_constraintTop_toBottomOf="@id/wf_btn_default"
+        app:waffleButtonStyle="Done" />
 
-        <me.donedone.waffle.android.widget.WaffleButton
-            android:id="@+id/wf_btn_done"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="done button"
-            app:waffleButtonStyle="Done" />
+    <Button
+        android:id="@+id/btn_primary"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="primary button"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@id/wf_btn_primary"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/btn_done"
+        app:waffleButtonStyle="Primary" />
 
-        <Button
-            android:id="@+id/btnPrimary"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="primary button"
-            app:waffleButtonStyle="Primary" />
-
-        <me.donedone.waffle.android.widget.WaffleButton
-            android:id="@+id/wf_btnPrimary"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="primary button"
-            app:waffleButtonStyle="Primary" />
-    </LinearLayout>
-</ScrollView>
+    <me.donedone.waffle.android.widget.WaffleButton
+        android:id="@+id/wf_btn_primary"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="primary button"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/btn_primary"
+        app:layout_constraintTop_toBottomOf="@id/wf_btn_done"
+        app:waffleButtonStyle="Primary" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/waffle/preview/src/main/res/layout/activity_waffle_button.xml
+++ b/waffle/preview/src/main/res/layout/activity_waffle_button.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Designed and developed by DoneDone Team 2023.
+  ~
+  ~ Licensed under the MIT.
+  ~ Please see full license: https://github.com/TodayDoneDone/donedone-android/blob/main/LICENSE
+  -->
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <Button
+            android:id="@+id/btn"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="button" />
+
+        <me.donedone.waffle.android.widget.WaffleButton
+            android:id="@+id/wf_btn"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="button" />
+
+        <Button
+            android:id="@+id/btn_default"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="default button"
+            app:waffleButtonStyle="Default" />
+
+        <me.donedone.waffle.android.widget.WaffleButton
+            android:id="@+id/wf_btn_default"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="default button"
+            app:waffleButtonStyle="Default" />
+
+        <Button
+            android:id="@+id/btn_done"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="done button"
+            app:waffleButtonStyle="Done" />
+
+        <me.donedone.waffle.android.widget.WaffleButton
+            android:id="@+id/wf_btn_done"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="done button"
+            app:waffleButtonStyle="Done" />
+
+        <Button
+            android:id="@+id/btnPrimary"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="primary button"
+            app:waffleButtonStyle="Primary" />
+
+        <me.donedone.waffle.android.widget.WaffleButton
+            android:id="@+id/wf_btnPrimary"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="primary button"
+            app:waffleButtonStyle="Primary" />
+    </LinearLayout>
+</ScrollView>

--- a/waffle/preview/src/main/res/layout/list_item_sample.xml
+++ b/waffle/preview/src/main/res/layout/list_item_sample.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Designed and developed by DoneDone Team 2023.
+  ~
+  ~ Licensed under the MIT.
+  ~ Please see full license: https://github.com/TodayDoneDone/donedone-android/blob/main/LICENSE
+  -->
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <data>
+
+        <variable
+            name="viewModel"
+            type="me.donedone.waffle.preview.MainActivity.SampleViewModel" />
+    </data>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:padding="8dp"
+        android:orientation="horizontal">
+
+        <TextView
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:textSize="24sp"
+            android:text="@{viewModel.title}" />
+
+        <me.donedone.waffle.android.widget.WaffleButton
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="go"
+            android:onClick="@{() -> viewModel.action.run()}"
+            app:waffleButtonStyle="Primary" />
+
+    </LinearLayout>
+</layout>


### PR DESCRIPTION
## Issue

- close #23 

## Overview (Required)

- waffle-preview 서브 모듈 추가
- WaffleSample 애노테이션을 이용하여서 SampleActivity 메인 엑티비티에서 취합하도록 구현 했습니다.

## Screenshot

|           Before           |           After            |
|:--------------------------:|:--------------------------:|
| <img src="" width="300" />  | WafflePreviewMain <br/> <img src="https://github.com/TodayDoneDone/donedone-android/assets/9072200/d693f21d-1f97-4477-b8b2-95f804432b83" width="300" /> |
| <img src="" width="300" />  | WaffleButton <br/> <img src="https://github.com/TodayDoneDone/donedone-android/assets/9072200/cadb5e51-0d3c-4f0e-b3f1-ed305129e6ad" width="300" /> |
